### PR TITLE
不改变B和C源码前提下的最简cmake结构

### DIFF
--- a/A/A.cpp
+++ b/A/A.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include "B.h"
-#include "C.h"
+#include "B/B.h"
+#include "C/C.h"
 
 
 int main(int, char**){

--- a/B/CMakeLists.txt
+++ b/B/CMakeLists.txt
@@ -1,12 +1,2 @@
 add_library(B B.cpp)
-
-## XY: 不需要这个
-#add_subdirectory(../D buildD1) #由于D不是B的子目录，因此需要指定第二个参数build_dir
 target_link_libraries(B D)
-
-
-# 为了外部调用B的库能自动包含B的头文件
-target_include_directories(
-    B INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -1,12 +1,2 @@
 add_library(C C.cpp)
-
-## XY: 不需要这个
-#add_subdirectory(../D buildD2) #由于D不是C的子目录，因此需要指定第二个参数build_dir
 target_link_libraries(C D)
-
-
-# 为了外部调用C的库能自动包含C的头文件
-target_include_directories(
-    C INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(MyProject)
 
-include_directories(D)
+include_directories("${CMAKE_SOURCE_DIR}")
+include_directories("${CMAKE_SOURCE_DIR}/D")
 
 add_subdirectory(A)
 add_subdirectory(B)

--- a/D/CMakeLists.txt
+++ b/D/CMakeLists.txt
@@ -1,6 +1,1 @@
 add_library(D D.cpp)
-
-target_include_directories(
-    D INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)


### PR DESCRIPTION
# 说明
```
include_directories("${CMAKE_SOURCE_DIR}")
```
上述代码的作用是告诉cmake把根目录当成寻找头文件的基路径，这样A.cpp里的`#include "B/B.h"`等就能找到了
```
include_directories("${CMAKE_SOURCE_DIR}/D")
```
上述代码的作用是将D目录include进来（因为B.h和C.h中用了`#include "D.h"`而不能修改为`#include "D/D.h"`。